### PR TITLE
Add sync fork GH action

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @medplum/dev
+* @ensomata/services-team

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,3 +1,5 @@
+# Temporarily disabled this on the repo
+# Will evaluate further as part of ENSOMATA-1100
 name: Build
 # Limit a single job to run at a time for a given branch/PR to save resources and speed up CI
 # see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,3 +1,5 @@
+# Temporarily disabled this on the repo
+# Will evaluate further as part of ENSOMATA-1100
 name: 'Chromatic'
 
 on: push

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,3 +1,5 @@
+# Temporarily disabled this on the repo
+# Will evaluate further as part of ENSOMATA-1100
 # For most projects, this workflow file will not need changing; you simply need
 # to commit it to your repository.
 #

--- a/.github/workflows/prettier-fmt.yml
+++ b/.github/workflows/prettier-fmt.yml
@@ -1,3 +1,5 @@
+# Temporarily disabled this on the repo
+# Will evaluate further as part of ENSOMATA-1100
 # Borrowed from: https://github.com/oven-sh/bun/blob/main/.github/workflows/prettier-fmt.yml
 name: prettier
 

--- a/.github/workflows/sync-fork.yml
+++ b/.github/workflows/sync-fork.yml
@@ -1,0 +1,17 @@
+name: Sync Fork
+
+on:
+  schedule:
+    - cron: '0 17 * * MON' # 5pm UTC every Monday
+  workflow_dispatch: # on button click
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: tgymnich/fork-sync@v1.9
+        with:
+          owner: ensomata
+          base: source
+          head: source


### PR DESCRIPTION
### Changes

- Add GH action that runs every Fri @ 5pm UTC that open up a PR to sync our fork on the `source` branch. I created the `source` branch via the GH UI already. The time/interval choice was arbitrary, happy to update if people have strong opinions.
- CODEOWNERS file edit should set this to auto assign the services team to these PRs
- Temporarily disabled all workflows except `assign-pull-request` and this one using the github UI + added notes about this

### Notes
- We'll then periodically use this `source` branch to bring in medplum updates into `main` with the changes we add [per convo](https://ensomata.slack.com/archives/C06JF6APTHU/p1708623602182269)
- I will do a second or possibly more PRs to evaluate/edit/remove those disabled workflows...the idea is to customize these to fit our needs